### PR TITLE
change run volume mount point

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,5 @@ RUN chmod 755 /start
 EXPOSE 6379
 
 VOLUME ["/var/lib/redis"]
-VOLUME ["/var/run/redis"]
+VOLUME ["/run/redis"]
 CMD ["/start"]


### PR DESCRIPTION
Similar to the postgres image, the run volume fails to mount. From the similar pull:

This is not working as is, Centos 6.5, `Docker version 1.1.2, build d84a070/1.1.2`. The ubuntu base image presents `/var/run` as a symlink to `/run`. As is, the image fails to start, throwing

```
lxc-start: No such file or directory - failed to mount '/var/lib/docker/vfs/dir/756ab52577b71bbc395e4705eb307eadbe813ceecc6bb6a46d83b31c95ef3c0d' on '/usr/lib64/lxc/rootfs///var/run/redis'
lxc-start: failed to setup the mount entries for '8cb1ca1c8c69ba3f13a3812b680cef5a52d3b1e2e8686f9e8e725c2f39e6feb3'
```

Modifying the volume to `/run` seems to resolve the problem.
