### PR TITLE
Upgrade to Redis 5.0.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:bionic-20190612
+FROM ubuntu:focal-20210713
 
 LABEL maintainer="sameer@damagehead.com"
 
-ENV REDIS_VERSION=4.0.9 \
+ENV REDIS_VERSION=5.0.7 \
     REDIS_USER=redis \
     REDIS_DATA_DIR=/var/lib/redis \
     REDIS_LOG_DIR=/var/log/redis


### PR DESCRIPTION
Redis changelog seems negligible for the upgrade: https://raw.githubusercontent.com/antirez/redis/5.0/00-RELEASENOTES

This is as that latest GitLab (e.g. https://github.com/sameersbn/docker-gitlab) reports it does not support 4.x when running the check tool (` sudo -u git -H bundle exec rake gitlab:check RAILS_ENV=production`). This hasn't had any issues with a docker-gitlab 14.0.x instance